### PR TITLE
Check for https as well when skipping stat call

### DIFF
--- a/libffmpegthumbnailer/videothumbnailer.cpp
+++ b/libffmpegthumbnailer/videothumbnailer.cpp
@@ -208,6 +208,7 @@ void VideoThumbnailer::writeImage(const string& videoFile, ImageWriter& imageWri
     if ((videoFile != "-") &&
         (videoFile.compare(0, 7, "rtsp://") != 0) &&
         (videoFile.compare(0, 6, "udp://") != 0) &&
+        (videoFile.compare(0, 8, "https://") != 0) &&
         (videoFile.compare(0, 7, "http://") != 0))
     {
         struct stat statInfo;


### PR DESCRIPTION
Fixes issue #140. In `VideoThumbnailer::writeImage` at [line 208](https://github.com/dirkvdb/ffmpegthumbnailer/blob/c4d4e2101f284f2900e7d9b9dd2171aff581ae57/libffmpegthumbnailer/videothumbnailer.cpp#L208) you have

```
    if ((videoFile != "-") &&
        (videoFile.compare(0, 7, "rtsp://") != 0) &&
        (videoFile.compare(0, 6, "udp://") != 0) &&
        (videoFile.compare(0, 7, "http://") != 0))
```

but you don't check for `https`, so if the URL has that protocol you attempt to stat it. I'm not sure why it doesn't happen when output is to a file, but if the output flag is `-o -` you then send the error message to stdout:

```
$ ffmpegthumbnailer -o - -c jpeg -i https:/... | hexdump -C
00000000  57 61 72 6e 3a 20 46 61  69 6c 65 64 20 74 6f 20  |Warn: Failed to |
00000010  73 74 61 74 20 66 69 6c  65 20 28 4e 6f 20 73 75  |stat file (No su|
00000020  63 68 20 66 69 6c 65 20  6f 72 20 64 69 72 65 63  |ch file or direc|
00000030  74 6f 72 79 29 0a ff d8  ff e0 00 10 4a 46 49 46  |tory).......JFIF|
00000040  00 01 01 00 00 01 00 01  00 00 ff db 00 43 00 06  |.............C..|
00000050  04 05 06 05 04 06 06 05  06 07 07 06 08 0a 10 0a  |................|
00000060  0a 09 09 0a 14 0e 0f 0c  10 17 14 18 18 17 14 16  |................|
00000070  16 1a 1d 25 1f 1a 1b 23  1c 16 16 20 2c 20 23 26  |...%...#... , #&|
00000080  27 29 2a 29 19 1f 2d 30  2d 28 30 25 28 29 28 ff  |')*)..-0-(0%()(.|
00000090  db 00 43 01 07 07 07 0a  08 0a 13 0a 0a 13 28 1a  |..C...........(.|
000000a0  16 1a 28 28 28 28 28 28  28 28 28 28 28 28 28 28  |..((((((((((((((|
000000b0  28 28 28 28 28 28 28 28  28 28 28 28 28 28 28 28  |((((((((((((((((|
...
```

This change adds a check for `https` to avoid this.
